### PR TITLE
Use universal ports for frontend and backend instead of defaults

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 RUN bunx prisma generate
 
 # Expose le port du serveur Elysia
-EXPOSE 3000
+EXPOSE 8080
 
 # Lance le serveur
 CMD ["bun", "run", "src/index.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services: #conteneur
     container_name: backend
     build: ./backend #dossier qui contient le Dockerfile
     ports:
-      - "3000:3000"
+      - "8080:8080"
     networks:
       - back-tier
       - front-tier
@@ -38,7 +38,7 @@ services: #conteneur
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -51,7 +51,7 @@ services: #conteneur
       context: ./frontend
       target: dev #utilise le stage dev du Dockerfile
     ports:
-      - "5173:5173"
+      - "3000:3000"
     networks:
       - front-tier
     environment:
@@ -60,7 +60,7 @@ services: #conteneur
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5173"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,7 @@ RUN bun install
 COPY . .
 
 # Expose le port du frontend
-EXPOSE 5173
+EXPOSE 3000
 
 # Lance le serveur de dev
 CMD ["bun", "run", "dev", "--host", "0.0.0.0"]


### PR DESCRIPTION
**Port configuration standardization:**

* Changed the exposed port in `backend/Dockerfile` from 3000 to 8080 to match the updated backend service port.
* Updated the backend service port mapping in `docker-compose.yml` from 3000:3000 to 8080:8080, and adjusted the health check to target port 8080.

**Frontend port alignment:**

* Changed the exposed port in `frontend/Dockerfile` from 5173 to 3000 to align with the frontend service port mapping.
* Updated the frontend service port mapping in `docker-compose.yml` from 5173:5173 to 3000:3000, and adjusted the health check to target port 3000.