### PR TITLE
fix: correct dash in CI job names and add missing Prisma adapter dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   backend:
-    name: Backend — type check & Prisma
+    name: Backend - type check & Prisma
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -34,7 +34,7 @@ jobs:
         run: bunx tsc --noEmit
 
   frontend:
-    name: Frontend — type check
+    name: Frontend - type check
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@elysiajs/cors": "latest",
+    "@prisma/adapter-pg": "latest",
     "@prisma/client": "latest",
     "elysia": "latest",
     "jose": "^6.2.3"


### PR DESCRIPTION
This pull request includes minor improvements to the project configuration and dependencies. The most notable changes are the addition of a new Prisma adapter dependency and small updates to CI workflow job names for consistency.

Dependency updates:

* Added `@prisma/adapter-pg` as a new dependency in `backend/package.json` to support PostgreSQL with Prisma.